### PR TITLE
DNP_ADMIN: Follow the Filesystem Hierarchy Standard of Linux.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM node as build-deps
-WORKDIR /usr/src/app
+WORKDIR /opt/app
 # ensuring both package.json AND package-lock.json are copied
 COPY src/package*.json ./
 # install dependencies
@@ -10,6 +10,6 @@ COPY src .
 RUN yarn run build
 
 FROM nginx:1.12-alpine
-COPY --from=build-deps /usr/src/app/build /usr/share/nginx/html
+COPY --from=build-deps /opt/app/build /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
The current data path is installed under /usr/src, a directory reserved
for linux kernel sources. Follow the Filesystem Hierarchy Standard
of Linux, and use /opt/dappnode instead.

Refs: https://github.com/dappnode/DAppNode/issues/39