### PR TITLE
show the possibility of deleting data in a dialog

### DIFF
--- a/build/src/src/packages/components/PackageInterface.jsx
+++ b/build/src/src/packages/components/PackageInterface.jsx
@@ -5,9 +5,7 @@ import * as action from "../actions";
 import { createStructuredSelector } from "reselect";
 import { push } from "connected-react-router";
 import { NAME } from "../constants";
-import { shortName } from "utils/format";
-import { confirmAlert } from "react-confirm-alert"; // Import
-import "react-confirm-alert/src/react-confirm-alert.css"; // Import css
+import confirmRemove from "./confirmRemove";
 // Components
 import Details from "./PackageViews/Details";
 import Logs from "./PackageViews/Logs";
@@ -17,28 +15,6 @@ import Controls from "./PackageViews/Controls";
 import parsePorts from "utils/parsePorts";
 
 class PackageInterface extends React.Component {
-  constructor(props) {
-    super(props);
-    this.removePackageConfirm = this.removePackageConfirm.bind(this);
-  }
-
-  removePackageConfirm(pkg, deleteVolumes) {
-    confirmAlert({
-      title: "Removing " + shortName(pkg.name),
-      message: "Are you sure?",
-      buttons: [
-        {
-          label: "Yes",
-          onClick: () => this.props.removePackage(pkg, deleteVolumes)
-        },
-        {
-          label: "No",
-          onClick: () => {}
-        }
-      ]
-    });
-  }
-
   render() {
     const pkg = this.props.pkg;
     if (!pkg) {
@@ -77,8 +53,7 @@ class PackageInterface extends React.Component {
           togglePackage={() => this.props.togglePackage(id)}
           restartPackage={() => this.props.restartPackage(id)}
           restartPackageVolumes={() => this.props.restartPackageVolumes(id)}
-          removePackage={() => this.removePackageConfirm(pkg, false)}
-          removePackageAndData={() => this.removePackageConfirm(pkg, true)}
+          removePackage={() => confirmRemove(pkg, this.props.removePackage)}
         />
       </div>
     );

--- a/build/src/src/packages/components/PackageRow.jsx
+++ b/build/src/src/packages/components/PackageRow.jsx
@@ -6,37 +6,14 @@ import { shortName } from "utils/format";
 import { colors } from "utils/format";
 import { connect } from "react-redux";
 import * as action from "../actions";
-import { confirmAlert } from "react-confirm-alert"; // Import
-import "react-confirm-alert/src/react-confirm-alert.css"; // Import css
+import confirmRemove from "./confirmRemove";
 // utils
 import parsePorts from "utils/parsePorts";
 
 class PackageRowView extends React.Component {
-  constructor(props) {
-    super(props);
-    this.removePackageConfirm = this.removePackageConfirm.bind(this);
-  }
-
   static propTypes = {
     moduleName: PropTypes.string.isRequired
   };
-
-  removePackageConfirm(pkg) {
-    confirmAlert({
-      title: "Removing " + shortName(pkg.name),
-      message: "Are you sure?",
-      buttons: [
-        {
-          label: "Yes",
-          onClick: () => this.props.removePackage(pkg)
-        },
-        {
-          label: "No",
-          onClick: () => {}
-        }
-      ]
-    });
-  }
 
   render() {
     let pkg = this.props.pkg || {};
@@ -86,7 +63,7 @@ class PackageRowView extends React.Component {
                   className="btn btn-outline-danger"
                   type="button"
                   style={{ width, paddingLeft: "0px", paddingRight: "0px" }}
-                  onClick={() => this.removePackageConfirm(this.props.pkg)}
+                  onClick={() => confirmRemove(pkg, this.props.removePackage)}
                 >
                   Remove
                 </button>
@@ -103,8 +80,8 @@ const mapStateToProps = createStructuredSelector({});
 
 const mapDispatchToProps = dispatch => {
   return {
-    removePackage: pkg => {
-      dispatch(action.removePackage({ id: pkg.name, deleteVolumes: false }));
+    removePackage: (pkg, deleteVolumes) => {
+      dispatch(action.removePackage({ id: pkg.name, deleteVolumes }));
       const ports = parsePorts(pkg.manifest || {});
       if (ports.length) dispatch(action.closePorts(ports));
     }

--- a/build/src/src/packages/components/PackageViews/Controls.jsx
+++ b/build/src/src/packages/components/PackageViews/Controls.jsx
@@ -33,17 +33,8 @@ export default class PackageControls extends React.Component {
       },
       {
         name: "Remove ",
-        text:
-          "Deletes a package permanently. All data not stored in volumes will be lost.",
+        text: "Deletes a package permanently.",
         action: this.props.removePackage,
-        availableForCore: false,
-        type: "danger"
-      },
-      {
-        name: "Remove + data",
-        text:
-          "Deletes a package and all its data permanently. Data stored in volumes will be also deleted",
-        action: this.props.removePackageAndData,
         availableForCore: false,
         type: "danger"
       }

--- a/build/src/src/packages/components/confirmRemove.js
+++ b/build/src/src/packages/components/confirmRemove.js
@@ -1,0 +1,30 @@
+import { confirmAlert } from "react-confirm-alert"; // Import
+import "react-confirm-alert/src/react-confirm-alert.css"; // Import css
+import { shortName } from "utils/format";
+
+function shortNameCapitalized(name = "") {
+  const _name = shortName(name);
+  return _name.charAt(0).toUpperCase() + _name.slice(1);
+}
+
+export default function confirmRemove(pkg, removePackage) {
+  const name = shortNameCapitalized(pkg.name);
+  confirmAlert({
+    title: `Removing ${name}`,
+    message: `This action cannot be undone. If you do NOT want to keep ${name}'s data remove it permanently with the "Remove DNP + data" option.`,
+    buttons: [
+      {
+        label: "Cancel",
+        onClick: () => {}
+      },
+      {
+        label: "Remove",
+        onClick: () => removePackage(pkg, false)
+      },
+      {
+        label: "Remove DNP + data",
+        onClick: () => removePackage(pkg, true)
+      }
+    ]
+  });
+}


### PR DESCRIPTION
The same dialog will show both in the DNP list and in the DNP dedicated page. I will show the following text:
This action cannot be undone. If you do NOT want to keep ${name}'s data remove it permanently with the "Remove DNP + data" option.
Then it will give three options
- Cancel
- Remove
- Remove DNP + data
