### PR TITLE
Change css layout to fix safari bug

### DIFF
--- a/build/src/src/App.jsx
+++ b/build/src/src/App.jsx
@@ -33,7 +33,7 @@ class App extends React.Component {
           {/* SideNav expands on big screens, while content-wrapper moves left */}
           <SideBar />
           <TopBar />
-          <main>
+          <div id="main">
             <ErrorBoundary>
               <NotificationsMain />
             </ErrorBoundary>
@@ -50,7 +50,7 @@ class App extends React.Component {
                 )}
               />
             ))}
-          </main>
+          </div>
           <ToastContainer />
         </div>
       );

--- a/build/src/src/App.jsx
+++ b/build/src/src/App.jsx
@@ -10,6 +10,7 @@ import ErrorBoundary from "./components/generic/ErrorBoundary";
 import TopBar from "./components/navbar/TopBar";
 import SideBar from "./components/navbar/SideBar";
 import Loading from "components/generic/Loading";
+import ScrollToTop from "components/ScrollToTop";
 // Pages
 import pages from "./pages";
 // Redux
@@ -51,7 +52,10 @@ class App extends React.Component {
               />
             ))}
           </div>
+
+          {/* Place here non-page components */}
           <ToastContainer />
+          <ScrollToTop />
         </div>
       );
     } else if (isNotAdmin) {

--- a/build/src/src/components/ScrollToTop.jsx
+++ b/build/src/src/components/ScrollToTop.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { withRouter } from "react-router-dom";
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children || null;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/build/src/src/components/navbar/SideBar.jsx
+++ b/build/src/src/components/navbar/SideBar.jsx
@@ -81,6 +81,8 @@ export default class SideBar extends React.Component {
           ))}
         </div>
 
+        <div className="spacer" />
+
         {/* mt-auto will push the div to the bottom */}
         <div className="funded-by">
           <div className="funded-by-text">SUPPORTED BY</div>

--- a/build/src/src/components/navbar/SideBar.jsx
+++ b/build/src/src/components/navbar/SideBar.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { NavLink } from "react-router-dom";
 import { sidenavItems, fundedBy } from "./navbarItems";
 import logo from "img/dappnode-logo-wide-min.png";
@@ -16,95 +16,98 @@ export function toggleSideNav() {
   window.dispatchEvent(new Event(toggleSideNavEvent));
 }
 
-export default class SideBar extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      sidenavCollapsed: true,
-      width: window.innerWidth,
-      breakPointPx: getBreakPointPx()
+export default function SideBar() {
+  const [collapsed, setCollapsed] = useState(true);
+  const [width, setWidth] = useState(window.innerWidth);
+
+  const sidebarEl = useRef(null);
+
+  function toggleSideNav() {
+    setCollapsed(!collapsed);
+  }
+  function collapseSideNav() {
+    setCollapsed(true);
+  }
+
+  useEffect(() => {
+    window.addEventListener(toggleSideNavEvent, toggleSideNav);
+    return () => {
+      window.removeEventListener(toggleSideNavEvent, toggleSideNav);
     };
-    this.onWindowResize = this.onWindowResize.bind(this);
-    this.toggleSideNav = this.toggleSideNav.bind(this);
-    this.collapseSideNav = this.collapseSideNav.bind(this);
-  }
+  }, []);
 
-  componentDidMount() {
-    window.addEventListener(toggleSideNavEvent, this.toggleSideNav);
-    window.addEventListener("resize", this.onWindowResize);
-  }
-  componentWillUnmount() {
-    window.removeEventListener(toggleSideNavEvent, this.toggleSideNav);
-    window.removeEventListener("resize", this.onWindowResize);
-  }
-
-  toggleSideNav() {
-    this.setState({ sidenavCollapsed: !this.state.sidenavCollapsed });
-  }
-  collapseSideNav() {
-    this.setState({ sidenavCollapsed: true });
-  }
-
-  // Always collapse the navbar when crossing the breakpoint, going from big to small
-  onWindowResize() {
-    const breakPointPx = getBreakPointPx();
-    if (this.state.width > breakPointPx && window.innerWidth <= breakPointPx) {
-      this.collapseSideNav();
+  useEffect(() => {
+    // Always collapse the navbar when crossing the breakpoint, going from big to small
+    function onWindowResize() {
+      const breakPointPx = getBreakPointPx();
+      if (width > breakPointPx && window.innerWidth <= breakPointPx)
+        collapseSideNav();
+      setWidth(window.innerWidth);
     }
-    this.setState({ width: window.innerWidth });
-  }
+    window.addEventListener("resize", onWindowResize);
+    return () => {
+      window.removeEventListener("resize", onWindowResize);
+    };
+  }, []);
 
-  render() {
-    const collapsed = this.state.sidenavCollapsed;
-    const collapseSideNav = this.collapseSideNav;
-    return (
-      <div id="sidebar" className={collapsed ? "collapsed" : ""}>
-        <NavLink className="top sidenav-item" to={"/"}>
-          <img className="sidebar-logo header" src={logo} alt="logo" />
-        </NavLink>
+  useEffect(() => {
+    if (collapsed) return; // Prevent unnecessary listeners
+    function handleMouseDown(e) {
+      if (!sidebarEl.current.contains(e.target)) setCollapsed(true);
+    }
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [collapsed]);
 
-        <div className="nav">
-          <div className="sidenav-item">
-            <div className="subheader">ADMIN UI</div>
-          </div>
+  return (
+    <div id="sidebar" ref={sidebarEl} className={collapsed ? "collapsed" : ""}>
+      <NavLink className="top sidenav-item" to={"/"} onClick={collapseSideNav}>
+        <img className="sidebar-logo header" src={logo} alt="logo" />
+      </NavLink>
 
-          {sidenavItems.map(item => (
-            <NavLink
-              key={item.name}
-              className="sidenav-item selectable"
-              onClick={collapseSideNav}
-              to={item.href}
-            >
-              <item.icon scale={0.8} />
-              <span className="name svg-text">{item.name}</span>
-            </NavLink>
+      <div className="nav">
+        <div className="sidenav-item">
+          <div className="subheader">ADMIN UI</div>
+        </div>
+
+        {sidenavItems.map(item => (
+          <NavLink
+            key={item.name}
+            className="sidenav-item selectable"
+            onClick={collapseSideNav}
+            to={item.href}
+          >
+            <item.icon scale={0.8} />
+            <span className="name svg-text">{item.name}</span>
+          </NavLink>
+        ))}
+      </div>
+
+      {/* spacer keeps the funded-by section at the bottom (if possible) */}
+      <div className="spacer" />
+
+      <div className="funded-by">
+        <div className="funded-by-text">SUPPORTED BY</div>
+        <div className="funded-by-logos">
+          {fundedBy.map((item, i) => (
+            <a key={i} href={item.link}>
+              <img
+                src={item.logo}
+                className="img-fluid funded-by-logo"
+                alt="logo"
+                data-toggle="tooltip"
+                data-placement="top"
+                title={item.text}
+                data-delay="300"
+              />
+            </a>
           ))}
         </div>
-
-        <div className="spacer" />
-
-        {/* mt-auto will push the div to the bottom */}
-        <div className="funded-by">
-          <div className="funded-by-text">SUPPORTED BY</div>
-          <div className="funded-by-logos">
-            {fundedBy.map((item, i) => (
-              <a key={i} href={item.link}>
-                <img
-                  src={item.logo}
-                  className="img-fluid funded-by-logo"
-                  alt="logo"
-                  data-toggle="tooltip"
-                  data-placement="top"
-                  title={item.text}
-                  data-delay="300"
-                />
-              </a>
-            ))}
-          </div>
-        </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 // Utility

--- a/build/src/src/components/navbar/sidebar.css
+++ b/build/src/src/components/navbar/sidebar.css
@@ -1,3 +1,8 @@
+#sidebar {
+  display: flex;
+  flex-direction: column;
+}
+
 /* Sidenav-item
    ============
  */
@@ -67,4 +72,12 @@
 }
 .funded-by-logo:hover {
   opacity: 0.5;
+}
+
+/* Spacer
+   ======
+   To generate a responsive design with flexbox 
+*/
+#sidebar > .spacer {
+  flex: auto;
 }

--- a/build/src/src/index.js
+++ b/build/src/src/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
-// ##### Investigate if HashRouter is really required
+// ##### TODO: Investigate if HashRouter is really required
 import { HashRouter as Router } from "react-router-dom";
 
 import store from "./store";

--- a/build/src/src/layout.css
+++ b/build/src/src/layout.css
@@ -30,6 +30,8 @@ body {
   /* Just by declaring flex the inner items (the svg) is centered vertically */
   display: flex;
   opacity: 0.7;
+  /* Increase clickable area */
+  min-height: calc(var(--topbar-height) / 2);
 }
 .sidenav-toggler:hover {
   opacity: 1;
@@ -144,6 +146,8 @@ body,
   background-color: var(--color-white);
   border-bottom: var(--border-style);
   padding: 0 var(--container-padding);
+  /* place topbar between the sidebar (2) and the main (0) */
+  z-index: 1;
 }
 #topbar .right,
 #topbar .left {
@@ -182,8 +186,6 @@ body,
   margin-left: var(--sidenav-width);
   background-color: var(--color-background);
   padding: var(--container-padding);
-  /* So the topbar dropdown menus are shown properly */
-  z-index: -1;
 }
 
 #main > div {

--- a/build/src/src/layout.css
+++ b/build/src/src/layout.css
@@ -1,7 +1,8 @@
 :root {
   --sidebar-breakpoint: 40rem;
   --sidenav-width: 12.5rem;
-  --topbar-width: 3.5rem;
+  --transition-time: 0.25s;
+  --topbar-height: 3.5rem;
   --container-padding: 1.5rem;
   --color-white: white;
   --color-border: #e5e5e5;
@@ -50,10 +51,6 @@ body,
   margin: 0;
   padding: 0;
   height: 100%;
-  /* On really small screens when the sidebar opens the whole page clips
-     prevent the appearing scrollbars by hidding the overflow
-   */
-  overflow: hidden;
 }
 
 /*****
@@ -65,11 +62,6 @@ body,
 */
 .body {
   height: 100vh;
-  display: grid;
-  grid-template:
-    "sidebar topbar" var(--topbar-width)
-    "sidebar main" auto
-    / auto 1fr;
 }
 
 /********
@@ -79,11 +71,13 @@ body,
   The responsiveness is controlled by making the width = 0 
 */
 #sidebar {
-  grid-area: sidebar;
   /* Basic sizing */
-  height: 100vh;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
   width: var(--sidenav-width);
-  transition: width 0.25s;
+  transition: width var(--transition-time);
   /* When the sidenav collapses, hidde its content */
   overflow: hidden;
   /* While the sidenav is collapsing, make sure the content stays straight */
@@ -94,14 +88,10 @@ body,
   box-shadow: rgba(0, 0, 0, 0.1) 1px 0px 15px;
   /* place sidebar on top of the header and content */
   z-index: 2;
-  /* Nested grid */
-  display: grid;
-  align-items: start;
-  grid-template-rows: var(--topbar-width) auto min-content;
 }
 /* SIDEBAR > TOP */
 #sidebar .top {
-  height: var(--topbar-width);
+  height: var(--topbar-height);
   border-bottom: var(--border-style);
 }
 .sidebar-logo {
@@ -128,13 +118,6 @@ body,
   grid-column: 2/4;
 }
 
-@media only screen and (max-width: 40rem) {
-  #sidebar.collapsed {
-    width: 0;
-    border-right-width: 0;
-  }
-}
-
 /* Styles below apply when screen width big */
 @media (min-width: 40rem) {
   .sidenav-toggler {
@@ -148,7 +131,11 @@ body,
   The topbar will always be visible and fixed on the top of the screen
 */
 #topbar {
-  grid-area: topbar;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--topbar-height);
   /* Postion left and right divs on each side + security gap margin */
   display: grid;
   grid-template-columns: auto auto;
@@ -189,15 +176,40 @@ body,
   Holds the app content. Content should be responsive on the x axis
   Overflow on the y axis is expected and will be scrollable
 */
-main {
-  grid-area: main;
-  overflow: auto;
+#main {
+  position: relative;
+  margin-top: var(--topbar-height);
+  margin-left: var(--sidenav-width);
   background-color: var(--color-background);
   padding: var(--container-padding);
+  /* So the topbar dropdown menus are shown properly */
+  z-index: -1;
 }
 
-main > div {
+#main > div {
   margin-bottom: var(--default-spacing);
+}
+
+/********************
+  RESPONSIVENESS
+  **************
+  Safari has been reported to cause issues with a grid-area 
+  responsive layout. When react re-painted the DOM, some
+  node's scroll position was reseted.
+*/
+#main,
+#topbar {
+  transition: margin-left var(--transition-time);
+}
+@media only screen and (max-width: 40rem) {
+  #sidebar.collapsed {
+    width: 0;
+    border-right-width: 0;
+  }
+  #main,
+  #topbar {
+    margin-left: 0;
+  }
 }
 
 /********************


### PR DESCRIPTION
CSS grids on safari where behaving incorrectly with React re-paints. The scroll was being reset on unreleated component updates. I couldn't find an explanation for the issue but change the layout approach from CSS grids to regular fixed position with variable margins seems to not cause the issue.