### PR TITLE
Strip non-alphanumeric characters from server name

### DIFF
--- a/build/src_openvpn/src/utils/getServerName.js
+++ b/build/src_openvpn/src/utils/getServerName.js
@@ -11,4 +11,11 @@ function getServerName(str) {
     return str;
 }
 
-export default getServerName
+// Remove all non-alphanumeric characters (including space)
+// In some Linux distributions it may cause problems
+function getCleanServerName(str) {
+  const serverName = getServerName(str) || "";
+  return serverName.replace(/\W/g, "");
+}
+
+export default getCleanServerName;


### PR DESCRIPTION
Remove all non-alphanumeric characters (including spaces) from the server name.
The server name becomes the file name of the .ovpn profile, and in some Linux distributions, it may cause problems if it contains spaces.