### PR TITLE
Remove spaces from server name concatenation

### DIFF
--- a/build/src_openvpn/src/utils/getServerName.js
+++ b/build/src_openvpn/src/utils/getServerName.js
@@ -1,13 +1,13 @@
 function getServerName(str) {
-    if (!str) return "DAppNode VPN";
+    if (!str) return "DAppNode_VPN";
     str = decodeURIComponent(str);
     const strLc = str.toLowerCase();
     if (!strLc.includes("dappnode") && !strLc.includes("vpn"))
-      return `${str} DAppNode VPN`;
+      return `${str}_DAppNode_VPN`;
     if (!strLc.includes("dappnode") && strLc.includes("vpn"))
-      return `${str} DAppNode`;
+      return `${str}_DAppNode`;
     if (strLc.includes("dappnode") && !strLc.includes("vpn"))
-      return `${str} VPN`;
+      return `${str}_VPN`;
     return str;
 }
 


### PR DESCRIPTION
Remove spaces from the server name concatenation.
The server name becomes the file name of the .ovpn profile, and in some Linux distributions, it may cause problems if it contains spaces.