### PR TITLE
Limit device name length

### DIFF
--- a/build/src/src/__tests__/pages/devices/helpers/coerceDeviceName.test.js
+++ b/build/src/src/__tests__/pages/devices/helpers/coerceDeviceName.test.js
@@ -1,0 +1,14 @@
+import coerceDeviceName from "../../../../pages/devices/helpers/coerceDeviceName";
+import { maxIdLength } from "../../../../pages/devices/data";
+
+describe("devices > helpers > coerceDeviceName", () => {
+  it("Should remove non-alphanumeric characters", () => {
+    const name = "Hello!%&%$   World";
+    expect(coerceDeviceName(name)).toEqual("HelloWorld");
+  });
+
+  it("Should limit device length", () => {
+    const name = "a".repeat(2000);
+    expect(coerceDeviceName(name).length).toEqual(maxIdLength);
+  });
+});

--- a/build/src/src/pages/devices/components/DevicesHome.jsx
+++ b/build/src/src/pages/devices/components/DevicesHome.jsx
@@ -4,7 +4,8 @@ import { createStructuredSelector } from "reselect";
 // Own module
 import DeviceGrid from "./DeviceGrid";
 import * as a from "../actions";
-import { title } from "../data";
+import { title, maxIdLength } from "../data";
+import coerceDeviceName from "../helpers/coerceDeviceName";
 // Services
 import { getDevices } from "services/devices/selectors";
 // Components
@@ -29,7 +30,7 @@ const DevicesHome = ({
         placeholder="Device's unique name"
         value={id}
         // Ensure id contains only alphanumeric characters
-        onValueChange={value => setId((value || "").replace(/\W/g, ""))}
+        onValueChange={value => setId(coerceDeviceName(value))}
         onEnterPress={() => {
           addDevice(id);
           setId("");
@@ -38,6 +39,12 @@ const DevicesHome = ({
           <ButtonLight onClick={() => addDevice(id)}>Add device</ButtonLight>
         }
       />
+
+      {id.length === maxIdLength ? (
+        <div className="alert alert-warning">
+          Device name must be shorter than {maxIdLength} characters
+        </div>
+      ) : null}
 
       <DeviceGrid
         devices={deviceList}

--- a/build/src/src/pages/devices/data.js
+++ b/build/src/src/pages/devices/data.js
@@ -6,3 +6,4 @@ export const title = "Devices";
 // Additional data
 export const guestsName = "Guests";
 export const guestsIpRange = "172.33.200.1-172.33.255.254";
+export const maxIdLength = 80;

--- a/build/src/src/pages/devices/helpers/coerceDeviceName.js
+++ b/build/src/src/pages/devices/helpers/coerceDeviceName.js
@@ -1,0 +1,11 @@
+import { maxIdLength } from "../data";
+
+export default function coerceDeviceName(name = "") {
+  // Replace non-alphanumeric characters
+  name = name.replace(/\W/g, "");
+
+  // Limit device length
+  if (name.length > maxIdLength) name = name.slice(0, maxIdLength);
+
+  return name;
+}


### PR DESCRIPTION
Device name limited at 80 characters. If more characters are typed, they will be ignored and a warning will show up.

![limit-device-length](https://user-images.githubusercontent.com/35266934/57763532-d5f84100-7701-11e9-9b3d-0ca2c3dbd9b0.png)
