### PR TITLE
Add manifest.updateAlerts functionality, show alerts based on update jumps

### DIFF
--- a/build/src/src/dappnode_colors.css
+++ b/build/src/src/dappnode_colors.css
@@ -128,3 +128,8 @@
 .badge-success {
   background-color: var(--success-color);
 }
+.alert-warning {
+  color: #433c1d;
+  background-color: #ffeda6;
+  border-color: #ffeda6;
+}

--- a/build/src/src/pages/system/components/SystemUpdateDetails.jsx
+++ b/build/src/src/pages/system/components/SystemUpdateDetails.jsx
@@ -7,27 +7,24 @@ import Linkify from "react-linkify";
 // Actions
 import { updateCore } from "services/coreUpdate/actions";
 // Selectors
-import { getCoreDeps, getCoreManifest } from "services/coreUpdate/selectors";
+import {
+  getCoreDeps,
+  getCoreManifest,
+  getCoreUpdateAlerts
+} from "services/coreUpdate/selectors";
 import { getIsLoadingStrictById } from "services/loadingStatus/selectors";
 import { loadingId as loadingIdCoreUpdate } from "services/coreUpdate/data";
 // Components
 import Card from "components/Card";
 import Button from "components/Button";
 import Loading from "components/generic/Loading";
-
-function OnInstallAlert({ manifest }) {
-  const { onInstall } = (manifest || {}).warnings || {};
-  if (!onInstall) return null;
-  return (
-    <div className="alert alert-warning" style={{ margin: "12px 0 6px 0" }}>
-      <Linkify>{onInstall}</Linkify>
-    </div>
-  );
-}
+// Icons
+import { FaArrowRight } from "react-icons/fa";
 
 const SystemUpdateDetails = ({
   coreDeps,
   coreManifest,
+  coreUpdateAlerts,
   isLoading,
   updateCore
 }) => {
@@ -36,13 +33,30 @@ const SystemUpdateDetails = ({
   /* If no deps, don't show the card */
   if (!coreDeps.length) return null;
 
-  const coreChangelog = (coreManifest || {}).changelog;
+  const { changelog, updateType } = coreManifest || {};
+  console.log({ updateType, coreUpdateAlerts });
+
   return (
     <Card className="system-update-grid">
       <div>
         <div className="section-card-subtitle">Core {coreManifest.version}</div>
-        {coreChangelog && <Linkify>{coreChangelog}</Linkify>}
-        <OnInstallAlert manifest={coreManifest} />
+        {changelog && <Linkify>{changelog}</Linkify>}
+
+        {coreUpdateAlerts.map(updateAlert => (
+          <div
+            className="alert alert-warning"
+            style={{ margin: "12px 0 6px 0" }}
+          >
+            {/* If there are multiple alerts, display the update jump */}
+            {coreUpdateAlerts.length > 1 && (
+              <div style={{ fontWeight: "bold" }}>
+                {updateAlert.from}{" "}
+                <FaArrowRight style={{ fontSize: ".7rem" }} /> {updateAlert.to}
+              </div>
+            )}
+            <Linkify>{updateAlert.message}</Linkify>
+          </div>
+        ))}
       </div>
 
       {/* Dedicated per core version update and warnings */}
@@ -57,7 +71,15 @@ const SystemUpdateDetails = ({
 
 SystemUpdateDetails.propTypes = {
   coreDeps: PropTypes.array.isRequired,
-  coreManifest: PropTypes.object
+  coreManifest: PropTypes.object,
+  coreUpdateAlerts: PropTypes.arrayOf(
+    PropTypes.shape({
+      from: PropTypes.string,
+      to: PropTypes.string,
+      message: PropTypes.string
+    })
+  ).isRequired,
+  isLoading: PropTypes.bool.isRequired
 };
 
 // Container
@@ -65,6 +87,7 @@ SystemUpdateDetails.propTypes = {
 const mapStateToProps = createStructuredSelector({
   coreDeps: getCoreDeps,
   coreManifest: getCoreManifest,
+  coreUpdateAlerts: getCoreUpdateAlerts,
   isLoading: getIsLoadingStrictById(loadingIdCoreUpdate)
 });
 

--- a/build/src/src/services/coreUpdate/sagas.js
+++ b/build/src/src/services/coreUpdate/sagas.js
@@ -124,7 +124,10 @@ export function* checkCoreUpdate() {
     yield put(a.updateCoreDeps(depManifests));
     yield put(updateIsLoaded(loadingId));
     /* Log out current state */
-    console.log(`DAppNode ${coreId} deps`, deps);
+    console.log(`DAppNode ${coreId} (${coreManifest.version}) deps`, {
+      deps,
+      coreManifest
+    });
   } catch (e) {
     console.error(`Error on checkCoreUpdate: ${e.stack}`);
   }


### PR DESCRIPTION
For the core.dnp.dappnode.eth update messages DO NOT use `warnings.onInstall` since it can lead to permanent message. 

New metadata to the manifest is supported in this manifest: `manifest.updateAlerts`

## Specs

See https://github.com/dappnode/DAppNode/wiki/Manifest-JSON-schema for full details

```js
{
  ...
  updateAlerts: [
    {
      from: "0.1.x",
      to: "0.2.x",
      message: "Critical update https://link-to-docs.io"
    }
  ]
}
```

## UI appearance

Single matching alert

![example-single](https://user-images.githubusercontent.com/35266934/57980983-669c8d00-7a32-11e9-9961-cb1df082a9fb.png)

Multiple matching alerts

![example-multiple](https://user-images.githubusercontent.com/35266934/57980987-6b614100-7a32-11e9-89b1-8b043a2e1233.png)

