### PR TITLE
Compute and display special permissions

### DIFF
--- a/build/src/src/components/ConfirmDialog.jsx
+++ b/build/src/src/components/ConfirmDialog.jsx
@@ -18,7 +18,16 @@ import "./confirmDialog.css";
  *   onClick: () => doImportantAction()
  * }, ... ]
  */
-function Modal({ title, text, buttons = [], label, onClick, variant, close }) {
+function Modal({
+  title,
+  text,
+  list,
+  buttons = [],
+  label,
+  onClick,
+  variant,
+  close
+}) {
   // If user clicks the modal itself, do not close
   const modalEl = useRef(null);
   function handleClickOverlay(e) {
@@ -38,13 +47,30 @@ function Modal({ title, text, buttons = [], label, onClick, variant, close }) {
       ref={modalEl}
       onClick={handleClickOverlay}
     >
-      <div className="dialog">
+      <div className="dialog no-p-style">
         {title && <h3 className="title">{title}</h3>}
         {text && (
           <div className="text">
             {typeof text === "string" ? <ReactMarkdown source={text} /> : text}
           </div>
         )}
+        {Array.isArray(list) && (
+          <div className="list">
+            {list.map((item, i) => (
+              <div key={item || i} className="list-item">
+                <strong>{item.title}</strong>
+                <div className="text">
+                  {typeof item.body === "string" ? (
+                    <ReactMarkdown source={item.body} />
+                  ) : (
+                    item.body
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
         <div className="buttons">
           {buttons.map(({ label, variant: localVariant, onClick }) => (
             <Button

--- a/build/src/src/components/confirmDialog.css
+++ b/build/src/src/components/confirmDialog.css
@@ -43,3 +43,17 @@
   margin-bottom: var(--default-spacing);
   white-space: pre-wrap;
 }
+
+.confirm-dialog-root > .dialog .list {
+  margin-top: 0.7rem;
+}
+.confirm-dialog-root > .dialog .list-item {
+  padding: 0.7rem 0;
+  border-bottom: var(--border-style);
+}
+.confirm-dialog-root > .dialog .list-item:first-child {
+  border-top: var(--border-style);
+}
+.confirm-dialog-root > .dialog .list-item > .text {
+  opacity: 0.8;
+}

--- a/build/src/src/dappnode_styles.css
+++ b/build/src/src/dappnode_styles.css
@@ -10,6 +10,12 @@ button.no-a-style:hover {
   text-decoration: inherit;
 }
 
+/* Change default <p> margin-bottom */
+.no-p-style p,
+p.no-p-style {
+  margin-bottom: 0;
+}
+
 /* General layout coloring */
 
 .vertical-container-centered {

--- a/build/src/src/mockState.js
+++ b/build/src/src/mockState.js
@@ -78,6 +78,34 @@ export const mockState = {
             "This software is experimental, presented 'as is' and inherently carries risks. By installing it, you acknowledge that DAppNode Association has done its best to mitigate these risks and accept to waive any liability or responsibility for DAppNode in case of any shortage, discrepancy, damage, loss or destruction of any digital asset managed within this DAppNode package.\n\nThis package stores private keys, which will be stored in your DAppNode. Neither DAppNode Association nor the developers of this software can have access to your private key, nor help you recover it if you lose it. \n\nYou are solely responsible for keeping your private keys and password safe and to perform secure backups, as well as to restrict access to your computer and other equipment. To the extent permitted by applicable law, you agree to be responsible for all activities that have been conducted from your account. You must take all necessary steps to ensure that your private key, password, and recovery phrase remain confidential and secured. \n\nThis is an Alpha version of experimental open source software released as a test version under an MIT license and may contain errors and/or bugs. No guarantee or representations whatsoever is made regarding its suitability (or its use) for any purpose or regarding its compliance with any applicable laws and regulations. Use of the software is at your own risk and discretion and by using the software you acknowledge that you have read this disclaimer, understand its contents, assume all risk related thereto and hereby release, waive, discharge and covenant not to sue Brainbot Labs Establishment or any officers, employees or affiliates from and for any direct or indirect liability resulting from the use of the software as permissible by applicable laws and regulations.\n\nPrivacy Warning: Please be aware, that by using the Raiden Client, \namong others, your Ethereum address, channels, channel deposits, settlements and the Ethereum address of your channel counterparty will be stored on the Ethereum chain, i.e. on servers of Ethereum node operators and ergo are to a certain extent publicly available. The same might also be stored on systems of parties running Raiden nodes connected to the same token network. Data present in the Ethereum chain is very unlikely to be able to be changed, removed or deleted from the public arena.\n\nAlso be aware, that data on individual Raiden token transfers will be made available via the Matrix protocol to the recipient, intermediating nodes of a specific transfer as well as to the Matrix server operators."
         }
       }
+    },
+    "vipnode.dnp.dappnode.eth": {
+      name: "vipnode.dnp.dappnode.eth",
+      whitelisted: true,
+      manifest: {
+        name: "vipnode.dnp.dappnode.eth",
+        version: "0.0.1",
+        description:
+          "https://vipnode.org - Economic incentive for running Ethereum full nodes. The goal is to allow the Ethereum network to remain decentralized by creating a financial marketplace for more people to run full nodes and serve native light clients.",
+        avatar:
+          "https://ipfs.io/ipfs/Qmen3srZXEHncMM2RPsgVKkPbkJPTMN9SNFVEAQQY4a7Nf",
+        type: "service",
+        image: {
+          path: "vipnode.dnp.dappnode.eth_0.0.1.tar.xz",
+          hash: "/ipfs/QmYnj7JtmDn4KuQADDNSAo2UwM9npjATjsX8AK12LewhyQ",
+          size: 7848217,
+          restart: "always",
+          environment: ["PAYOUT_ADDRESS="],
+          external_vol: ["dncore_ethchaindnpdappnodeeth_data:/app/.ethchain:ro"]
+        },
+        dependencies: {},
+        disclaimer: {
+          message:
+            "This software is experimental, presented 'as is' and inherently carries risks. By installing it, you acknowledge that DAppNode Association has done its best to mitigate these risks and accept to waive any liability or responsibility for DAppNode in case of any shortage, discrepancy, damage, loss or destruction of any digital asset managed within this DAppNode package.\n\nThis package stores private keys, which will be stored in your DAppNode. Neither DAppNode Association nor the developers of this software can have access to your private key, nor help you recover it if you lose it. \n\nYou are solely responsible for keeping your private keys and password safe and to perform secure backups, as well as to restrict access to your computer and other equipment. To the extent permitted by applicable law, you agree to be responsible for all activities that have been conducted from your account. You must take all necessary steps to ensure that your private key, password, and recovery phrase remain confidential and secured. \n\nThis is an Alpha version of experimental open source software released as a test version under an MIT license and may contain errors and/or bugs. No guarantee or representations whatsoever is made regarding its suitability (or its use) for any purpose or regarding its compliance with any applicable laws and regulations. Use of the software is at your own risk and discretion and by using the software you acknowledge that you have read this disclaimer, understand its contents, assume all risk related thereto and hereby release, waive, discharge and covenant not to sue Brainbot Labs Establishment or any officers, employees or affiliates from and for any direct or indirect liability resulting from the use of the software as permissible by applicable laws and regulations.\n\nPrivacy Warning: Please be aware, that by using the Raiden Client, \namong others, your Ethereum address, channels, channel deposits, settlements and the Ethereum address of your channel counterparty will be stored on the Ethereum chain, i.e. on servers of Ethereum node operators and ergo are to a certain extent publicly available. The same might also be stored on systems of parties running Raiden nodes connected to the same token network. Data present in the Ethereum chain is very unlikely to be able to be changed, removed or deleted from the public arena.\n\nAlso be aware, that data on individual Raiden token transfers will be made available via the Matrix protocol to the recipient, intermediating nodes of a specific transfer as well as to the Matrix server operators."
+        }
+      },
+      avatar:
+        "https://ipfs.io/ipfs/Qmen3srZXEHncMM2RPsgVKkPbkJPTMN9SNFVEAQQY4a7Nf"
     }
   },
 

--- a/build/src/src/pages/installer/components/InstallCardComponents/DependencyList.jsx
+++ b/build/src/src/pages/installer/components/InstallCardComponents/DependencyList.jsx
@@ -27,7 +27,7 @@ function OnInstallAlert({ manifest }) {
   if (!onInstall) return null;
   return (
     <div className="alert alert-warning" style={{ margin: "12px 0 6px 0" }}>
-      <ReactMarkdown source={onInstall} />
+      <ReactMarkdown className="no-p-style" source={onInstall} />
     </div>
   );
 }

--- a/build/src/src/pages/installer/components/InstallCardComponents/Details.jsx
+++ b/build/src/src/pages/installer/components/InstallCardComponents/Details.jsx
@@ -34,7 +34,7 @@ function Details({ dnp }) {
       <div>
         <ReadMore>
           <header>About this DNP</header>
-          <ReactMarkdown source={description} />
+          <ReactMarkdown className="no-p-style" source={description} />
         </ReadMore>
 
         <div className="data">

--- a/build/src/src/pages/installer/components/InstallCardComponents/SpecialPermissions.jsx
+++ b/build/src/src/pages/installer/components/InstallCardComponents/SpecialPermissions.jsx
@@ -1,13 +1,36 @@
 import React from "react";
+import ReactMarkdown from "react-markdown";
 // Components
-import Card from "components/Card";
+import CardList from "components/CardList";
 import SubTitle from "components/SubTitle";
+// Parsers
+import parseSpecialPermissions from "../../parsers/parseSpecialPermissions";
 
-const SpecialPermissions = () => (
-  <>
-    <SubTitle>Special Permissions</SubTitle>
-    <Card>Requires no special permissions</Card>
-  </>
-);
+const SpecialPermissions = ({ dnp }) => {
+  /**
+   * @param specialPermissions = [{
+   *   name: "Short description",
+   *   details: "Long description of the capabilitites"
+   * }, ... ]
+   */
+  const specialPermissions = parseSpecialPermissions(dnp.manifest);
+  if (!specialPermissions.length) return null;
+  // "Requires no special permissions"
+  return (
+    <>
+      <SubTitle>Special Permissions</SubTitle>
+      <CardList>
+        {specialPermissions.map(permission => (
+          <div key={permission.name}>
+            <strong>{permission.name}</strong>
+            <div className="no-p-style" style={{ opacity: 0.6 }}>
+              <ReactMarkdown source={permission.details} />
+            </div>
+          </div>
+        ))}
+      </CardList>
+    </>
+  );
+};
 
 export default SpecialPermissions;

--- a/build/src/src/pages/installer/components/InstallerSinglePkg.jsx
+++ b/build/src/src/pages/installer/components/InstallerSinglePkg.jsx
@@ -71,6 +71,7 @@ function InstallerInterface({
   return (
     <>
       <ProgressLogs progressLogs={progressLogs} />
+
       <Card className="installer-header">
         <Details dnp={dnp} />
         {availableOptions.map(option => (
@@ -87,11 +88,14 @@ function InstallerInterface({
           </Button>
         )}
       </Card>
+
       <Dependencies
         request={requestResult || {}}
         resolving={resolving || false}
       />
-      <SpecialPermissions />
+
+      <SpecialPermissions dnp={dnp} />
+
       {showSettings ? (
         <>
           <Envs />

--- a/build/src/src/pages/installer/parsers/parseSpecialPermissions.js
+++ b/build/src/src/pages/installer/parsers/parseSpecialPermissions.js
@@ -1,0 +1,70 @@
+/**
+ * - Usage of an external volume
+ * - Priviledged
+ * @param {object} manifest
+ * @returns {array} permissions = [{
+ *   name: "Short description",
+ *   details: "Long description of the capabilitites"
+ * }, ... ]
+ */
+function parseSpecialPermissions(manifest = {}) {
+  const specialPermissions = [];
+
+  const { external_vol, ipv4_address, network_mode, privileged, cap_add } =
+    manifest.image || {};
+
+  for (const externalVol of external_vol || []) {
+    // externalVol = "dncore_ethchaindnpdappnodeeth_data:/app/.ethchain:ro"
+    const host = externalVol.split(":")[0];
+    const parts = host.split("_");
+    if (parts[0] === "dncore")
+      specialPermissions.push({
+        name: "Access to core volume",
+        details: `Allows the DNP to read and write to the core volume ${host}`
+      });
+    else
+      specialPermissions.push({
+        name: "Access to DNP volume",
+        details: `Allows the DNP to read and write to the DNP volume ${host}`
+      });
+  }
+
+  const priviledgedDetails =
+    "Allows the DNP to manipulate and read any installed DNP and install additional packages. Allows the DNP to fully interact with the host system";
+
+  if (
+    manifest.type === "dncore" ||
+    privileged ||
+    (cap_add || []).includes("ALL")
+  )
+    specialPermissions.push({
+      name: "Priviledged access to the system host",
+      details: priviledgedDetails
+    });
+
+  if (manifest.type === "dncore" && ipv4_address)
+    specialPermissions.push({
+      name: "Admin priviledges in DAppNode's WAMP",
+      details:
+        "Allows the DNP to call any WAMP method of any DNP restricted to admin users"
+    });
+
+  for (const cap of cap_add || []) {
+    if (cap !== "ALL")
+      specialPermissions.push({
+        name: `Priviledged system capability ${cap}`,
+        details: `See docker docs for more information https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities`
+      });
+  }
+
+  if (network_mode === "host")
+    specialPermissions.push({
+      name: `Access to the host network`,
+      details:
+        "Allows the DNP connect directly to the host's network. It can bind its open ports directly to the host's IP address"
+    });
+
+  return specialPermissions;
+}
+
+module.exports = parseSpecialPermissions;

--- a/build/src/src/pages/installer/parsers/parseSpecialPermissions.js
+++ b/build/src/src/pages/installer/parsers/parseSpecialPermissions.js
@@ -1,6 +1,6 @@
 /**
  * - Usage of an external volume
- * - Priviledged
+ * - Privileged
  * @param {object} manifest
  * @returns {array} permissions = [{
  *   name: "Short description",
@@ -29,22 +29,20 @@ function parseSpecialPermissions(manifest = {}) {
       });
   }
 
-  const priviledgedDetails =
-    "Allows the DNP to manipulate and read any installed DNP and install additional packages. Allows the DNP to fully interact with the host system";
-
   if (
     manifest.type === "dncore" ||
     privileged ||
     (cap_add || []).includes("ALL")
   )
     specialPermissions.push({
-      name: "Priviledged access to the system host",
-      details: priviledgedDetails
+      name: "Privileged access to the system host",
+      details:
+        "Allows the DNP to manipulate and read any installed DNP and install additional packages. Allows the DNP to fully interact with the host system"
     });
 
   if (manifest.type === "dncore" && ipv4_address)
     specialPermissions.push({
-      name: "Admin priviledges in DAppNode's WAMP",
+      name: "Admin privileges in DAppNode's WAMP",
       details:
         "Allows the DNP to call any WAMP method of any DNP restricted to admin users"
     });
@@ -52,7 +50,7 @@ function parseSpecialPermissions(manifest = {}) {
   for (const cap of cap_add || []) {
     if (cap !== "ALL")
       specialPermissions.push({
-        name: `Priviledged system capability ${cap}`,
+        name: `Privileged system capability ${cap}`,
         details: `See docker docs for more information https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities`
       });
   }
@@ -61,7 +59,7 @@ function parseSpecialPermissions(manifest = {}) {
     specialPermissions.push({
       name: `Access to the host network`,
       details:
-        "Allows the DNP connect directly to the host's network. It can bind its open ports directly to the host's IP address"
+        "Allows the DNP to connect directly to the host's network. It can bind its open ports directly to the host's IP address"
     });
 
   return specialPermissions;

--- a/build/src/src/pages/packages/components/PackageViews/Details/index.jsx
+++ b/build/src/src/pages/packages/components/PackageViews/Details/index.jsx
@@ -27,7 +27,7 @@ function PackageDetails({ dnp }) {
           <header>
             <strong>Description</strong>
           </header>
-          <ReactMarkdown source={description} />
+          <ReactMarkdown className="no-p-style" source={description} />
         </ReadMore>
 
         <div>

--- a/build/src/src/pages/system/components/SystemUpdateDetails.jsx
+++ b/build/src/src/pages/system/components/SystemUpdateDetails.jsx
@@ -39,7 +39,9 @@ const SystemUpdateDetails = ({
     <Card className="system-update-grid">
       <div>
         <div className="section-card-subtitle">Core {coreManifest.version}</div>
-        {changelog && <ReactMarkdown source={changelog} />}
+        {changelog && (
+          <ReactMarkdown className="no-p-style" source={changelog} />
+        )}
 
         {coreUpdateAlerts.map(updateAlert => (
           <div


### PR DESCRIPTION
## Specs

Currently will detect and process the following manifest properties:

> *Note the display list format*
> - *condition to show `permission requirement`*
>    - ***Title of the permission***
>    - *Details of the permission*

- for each `external_vol`:
  - **Access to core volume**
  - Allows the DNP to read and write to the core volume ${host}
- if `type === "dncore" || privileged || (cap_add || []).includes("ALL")`
  - **Privileged access to the system host**
  - Allows the DNP to manipulate and read any installed DNP and install additional packages. Allows the DNP to fully interact with the host system
- if `type === "dncore" && ipv4_address`
  - **Admin privileges in DAppNode's WAMP**
  - Allows the DNP to call any WAMP method of any DNP restricted to admin users
- for each `cap_add` except `"ALL"`
  - **Priviledged system capability ${cap}**
  - See docker docs for more information https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
- if `network_mode === "host"`
  - **Access to the host network**
  - Allows the DNP to connect directly to the host's network. It can bind its open ports directly to the host's IP address

## Example

The `vipnode.dnp.dappnode.eth` only requires the **Access to core volume** permission.

#### Pop-up

![popup-sp](https://user-images.githubusercontent.com/35266934/59364047-86c02300-8d36-11e9-80e7-06cec9d3f64a.png)

#### On page display

![special-permissions](https://user-images.githubusercontent.com/35266934/59355784-f2e75a80-8d27-11e9-8455-79522a4a722b.png)
