### PR TITLE
deal with volumes with multiple links

### DIFF
--- a/build/src/src/components/ConfirmDialog.jsx
+++ b/build/src/src/components/ConfirmDialog.jsx
@@ -57,7 +57,7 @@ function Modal({
         {Array.isArray(list) && (
           <div className="list">
             {list.map((item, i) => (
-              <div key={item || i} className="list-item">
+              <div key={i} className="list-item">
                 <strong>{item.title}</strong>
                 <div className="text">
                   {typeof item.body === "string" ? (

--- a/build/src/src/pages/packages/actions.js
+++ b/build/src/src/pages/packages/actions.js
@@ -47,45 +47,78 @@ export const restartPackage = id => (_, getState) => {
   });
 };
 
-export const restartPackageVolumes = id => (_, getState) => {
+export const restartPackageVolumes = id => async (_, getState) => {
   // Make sure there are no colliding volumes with this DNP
+  const dnp = getDnpInstalledById(getState(), id);
+
+  const list = [];
+  if (dnp.name === "ethchain.dnp.dappnode.eth")
+    list.push({
+      title: "Warning! Resync time",
+      body: "The mainnet chain will have to resync and may take a few days"
+    });
+
+  /**
+   * If there are volumes which this DNP is the owner and some other
+   * DNPs are users, they will be removed by the DAPPMANAGER.
+   * Alert the user about this fact
+   */
+  const dnpsToRemoveWarning = getDnpsToRemoveWarning(dnp);
+  if (dnpsToRemoveWarning) list.push(dnpsToRemoveWarning);
 
   // If there are NOT conflicting volumes,
   // Display a dialog to confirm volumes reset
-  confirm({
-    title: `Removing ${sn(id)} data`,
-    text: `This action cannot be undone. If this DNP is a blockchain node, it will lose all the chain data and start syncing from scratch.`,
-    label: "Remove volumes",
-    onClick: () =>
-      api.restartPackageVolumes(
-        { id },
-        { toastMessage: `Removing volumes of ${sn(id)}...` }
-      )
-  });
+  await new Promise(resolve =>
+    confirm({
+      title: `Removing ${sn(id)} data`,
+      text: `This action cannot be undone. If this DNP is a blockchain node, it will lose all the chain data and start syncing from scratch.`,
+      list: list.length ? list : null,
+      label: "Remove volumes",
+      onClick: resolve
+    })
+  );
+
+  await api.restartPackageVolumes(
+    { id },
+    { toastMessage: `Removing volumes of ${sn(id)}...` }
+  );
 };
 
-export const removePackage = id => (_, getState) => {
+export const removePackage = id => async (_, getState) => {
+  const dnp = getDnpInstalledById(getState(), id);
+
   // Dialog to confirm remove + USER INPUT for delete volumes
-  const removePackageCallback = deleteVolumes =>
-    api.removePackage(
-      { id, deleteVolumes },
-      {
-        toastMessage: `Removing ${sn(id)} ${
-          deleteVolumes ? " and volumes" : ""
-        }...`
-      }
+  const deleteVolumes = await new Promise(resolve =>
+    confirm({
+      title: `Removing ${sn(id)}`,
+      text: `This action cannot be undone. If you do NOT want to keep ${id}'s data, remove it permanently clicking the "Remove DNP + data" option.`,
+      buttons: [
+        { label: "Remove", onClick: resolve.bind(this, false) },
+        { label: "Remove DNP + data", onClick: resolve.bind(this, true) }
+      ]
+    })
+  );
+
+  const dnpsToRemoveWarning = getDnpsToRemoveWarning(dnp);
+  if (dnpsToRemoveWarning)
+    await new Promise(resolve =>
+      confirm({
+        title: `Removing ${sn(id)} data`,
+        text: `This action cannot be undone.`,
+        list: [dnpsToRemoveWarning],
+        label: "Remove DNP and volumes",
+        onClick: resolve
+      })
     );
-  confirm({
-    title: `Removing ${sn(id)}`,
-    text: `This action cannot be undone. If you do NOT want to keep ${id}'s data, remove it permanently clicking the "Remove DNP + data" option.`,
-    buttons: [
-      { label: "Remove", onClick: () => removePackageCallback(false) },
-      {
-        label: "Remove DNP + data",
-        onClick: () => removePackageCallback(true)
-      }
-    ]
-  });
+
+  await api.removePackage(
+    { id, deleteVolumes },
+    {
+      toastMessage: `Removing ${sn(id)} ${
+        deleteVolumes ? " and volumes" : ""
+      }...`
+    }
+  );
 };
 
 // File manager
@@ -105,3 +138,28 @@ export const cleanCache = () => () =>
     label: "Clean cache",
     onClick: () => api.cleanCache({}, { toastMessage: `Cleaning cache...` })
   });
+
+/**
+ * Re-used disclaimers and warnings
+ */
+
+/**
+ * If there are volumes which this DNP is the owner and some other
+ * DNPs are users, they will be removed by the DAPPMANAGER.
+ * Alert the user about this fact
+ */
+function getDnpsToRemoveWarning(dnp) {
+  const dnpsToRemoveObj = {};
+  for (const vol of dnp.volumes || [])
+    if (vol.name && vol.isOwner && vol.users.length > 1)
+      for (const dnpName of vol.users)
+        if (dnpName !== dnp.name) dnpsToRemoveObj[dnpName] = true;
+  const dnpsToRemove = Object.keys(dnpsToRemoveObj);
+  if (dnpsToRemove.length) {
+    const dnpNames = dnpsToRemove.join(", ");
+    return {
+      title: "Warning! DNPs to be removed",
+      body: `${dnpNames} will be reseted in order to remove the volumes`
+    };
+  }
+}

--- a/build/src/src/pages/packages/actions.js
+++ b/build/src/src/pages/packages/actions.js
@@ -63,8 +63,12 @@ export const restartPackageVolumes = id => async (_, getState) => {
    * DNPs are users, they will be removed by the DAPPMANAGER.
    * Alert the user about this fact
    */
-  const dnpsToRemoveWarning = getDnpsToRemoveWarning(dnp);
-  if (dnpsToRemoveWarning) list.push(dnpsToRemoveWarning);
+  const dnpsToRemove = getDnpsToRemove(dnp);
+  if (dnpsToRemove)
+    list.push({
+      title: "Warning! DNPs to be removed",
+      body: `${dnpsToRemove} will be reseted in order to remove the volumes`
+    });
 
   // If there are NOT conflicting volumes,
   // Display a dialog to confirm volumes reset
@@ -99,13 +103,18 @@ export const removePackage = id => async (_, getState) => {
     })
   );
 
-  const dnpsToRemoveWarning = getDnpsToRemoveWarning(dnp);
-  if (dnpsToRemoveWarning)
+  const dnpsToRemove = getDnpsToRemove(dnp);
+  if (dnpsToRemove)
     await new Promise(resolve =>
       confirm({
         title: `Removing ${sn(id)} data`,
         text: `This action cannot be undone.`,
-        list: [dnpsToRemoveWarning],
+        list: [
+          {
+            title: "Warning! DNPs to be removed",
+            body: `${dnpsToRemove} will be removed as well because they are dependent on ${id} volumes`
+          }
+        ],
         label: "Remove DNP and volumes",
         onClick: resolve
       })
@@ -148,18 +157,11 @@ export const cleanCache = () => () =>
  * DNPs are users, they will be removed by the DAPPMANAGER.
  * Alert the user about this fact
  */
-function getDnpsToRemoveWarning(dnp) {
+function getDnpsToRemove(dnp) {
   const dnpsToRemoveObj = {};
   for (const vol of dnp.volumes || [])
     if (vol.name && vol.isOwner && vol.users.length > 1)
       for (const dnpName of vol.users)
         if (dnpName !== dnp.name) dnpsToRemoveObj[dnpName] = true;
-  const dnpsToRemove = Object.keys(dnpsToRemoveObj);
-  if (dnpsToRemove.length) {
-    const dnpNames = dnpsToRemove.join(", ");
-    return {
-      title: "Warning! DNPs to be removed",
-      body: `${dnpNames} will be reseted in order to remove the volumes`
-    };
-  }
+  return Object.keys(dnpsToRemoveObj).join(", ");
 }

--- a/build/src/src/schemas/index.js
+++ b/build/src/src/schemas/index.js
@@ -148,7 +148,7 @@ export const dnpInstalledItem = Joi.object({
   version: Joi.string().required(),
   isDnp: Joi.boolean().required(),
   isCore: Joi.boolean().required(),
-  created: Joi.string().required(),
+  created: [Joi.number(), Joi.string()],
   image: Joi.string().required(),
   name: Joi.string().required(),
   shortName: Joi.string(), // ###### TODO: remove


### PR DESCRIPTION
### vipnode package view

A text tells the user to go the ethchain view in order to delete the external volume

**NOTE: That hitting removePackage + data on a DNP that has dependent DNP using its volumes as external must be removed aswell. A docker-compose.yml declaring a volume as external will not succeed `up` if that volume does not exist**

---

![vipnode](https://user-images.githubusercontent.com/35266934/59464181-0b3e9e80-8e28-11e9-94c9-c547f6e12158.png)

---

### ethchain package view after clicking "Remove volumes"

The DAPPMANAGER will `rm` and `up` the vipnode package, so the user is alerted on the pop-up

---

![removevolumes](https://user-images.githubusercontent.com/35266934/59464215-1bef1480-8e28-11e9-8826-34addae33fa1.png)

---