### PR TITLE
Add reboot host view in /system

### DIFF
--- a/build/src/src/API/rpcMethods/dappmanager.js
+++ b/build/src/src/API/rpcMethods/dappmanager.js
@@ -462,6 +462,16 @@ export default {
   passwordIsSecure: {},
 
   /**
+   * Instruct the host to poweroff
+   */
+  poweroffHost: {},
+
+  /**
+   * Instruct the host to reboot
+   */
+  rebootHost: {},
+
+  /**
    * [removePackage]
    * Remove package data: docker down + disk files
    *

--- a/build/src/src/pages/system/components/PowerManagment.jsx
+++ b/build/src/src/pages/system/components/PowerManagment.jsx
@@ -8,24 +8,24 @@ import SubTitle from "components/SubTitle";
 import Columns from "components/Columns";
 import Button from "components/Button";
 
-function RebootHost() {
+function PowerManagment() {
   function reboot() {
     confirm({
       title: `Rebooting host`,
-      text: `Are you sure you want to reboot the host? Only do this action if it's stricly necessary.`,
+      text: `Are you sure you want to reboot the host machine? Only do this if it’s strictly necessary.`,
       label: "Reboot",
       onClick: () => api.rebootHost({}, { toastMessage: `Rebooting host...` }),
       variant: "danger"
     });
   }
 
-  async function shutdown() {
+  async function powerOff() {
     // Since there are two consecutive modals, the async form must be used
     await new Promise(resolve =>
       confirm({
-        title: `Shuting down host`,
-        text: `WARNING! You will not be able to turn back on your DAppNode from the admin UI, you will have to manually (or physically) start it again. Only do this action if it's stricly necessary, or you know what you are doing.`,
-        label: "Shutdown",
+        title: `Powering off host`,
+        text: `WARNING! Your machine will power off and you will not be able to turn it back on without physical access or a remote way to switch on the power.`,
+        label: "Power off",
         onClick: resolve,
         variant: "danger"
       })
@@ -34,27 +34,27 @@ function RebootHost() {
     await new Promise(resolve =>
       confirm({
         title: `Are you sure?`,
-        text: `You will not be able to turn back on your DAppNode from the admin UI.`,
-        label: "I am sure, shutdown",
+        text: `Please make sure you have a way of turning the host machine’s power back on.`,
+        label: "I am sure, power off",
         onClick: resolve,
         variant: "danger"
       })
     );
 
-    await api.poweroffHost({}, { toastMessage: `Shutting down host...` });
+    await api.poweroffHost({}, { toastMessage: `Powering off down host...` });
   }
 
   return (
     <>
-      <SubTitle>Reboot host</SubTitle>
+      <SubTitle>Power management</SubTitle>
       <Card className="backup">
         {/* Get backup */}
         <Columns>
           <div>
             <div className="subtle-header">REBOOT HOST</div>
             <p>
-              Only use this functionality if it's stricly necessary and the last
-              resource to solve a problem.
+              Only use this functionality as last resort and when all other
+              troubleshooting options have been exhausted.
             </p>
             <Button
               onClick={reboot}
@@ -67,17 +67,17 @@ function RebootHost() {
 
           {/* Restore backup */}
           <div>
-            <div className="subtle-header">SHUTDOWN HOST</div>
+            <div className="subtle-header">POWER OFF HOST</div>
             <p>
-              You will not be able to start your DAppNode from the admin UI, you
-              will have to do it manually.
+              Your machine will power off and you will not be able to access the
+              Admin UI until you turn it back on.
             </p>
             <Button
-              onClick={shutdown}
+              onClick={powerOff}
               // disabled={isOnProgress}
               variant="outline-danger"
             >
-              Shutdown
+              Power off
             </Button>
           </div>
         </Columns>
@@ -86,4 +86,4 @@ function RebootHost() {
   );
 }
 
-export default RebootHost;
+export default PowerManagment;

--- a/build/src/src/pages/system/components/RebootHost.jsx
+++ b/build/src/src/pages/system/components/RebootHost.jsx
@@ -1,0 +1,89 @@
+import React from "react";
+import api from "API/rpcMethods";
+import { confirm } from "components/ConfirmDialog";
+
+// Components
+import Card from "components/Card";
+import SubTitle from "components/SubTitle";
+import Columns from "components/Columns";
+import Button from "components/Button";
+
+function RebootHost() {
+  function reboot() {
+    confirm({
+      title: `Rebooting host`,
+      text: `Are you sure you want to reboot the host? Only do this action if it's stricly necessary.`,
+      label: "Reboot",
+      onClick: () => api.rebootHost({}, { toastMessage: `Rebooting host...` }),
+      variant: "danger"
+    });
+  }
+
+  async function shutdown() {
+    // Since there are two consecutive modals, the async form must be used
+    await new Promise(resolve =>
+      confirm({
+        title: `Shuting down host`,
+        text: `WARNING! You will not be able to turn back on your DAppNode from the admin UI, you will have to manually (or physically) start it again. Only do this action if it's stricly necessary, or you know what you are doing.`,
+        label: "Shutdown",
+        onClick: resolve,
+        variant: "danger"
+      })
+    );
+
+    await new Promise(resolve =>
+      confirm({
+        title: `Are you sure?`,
+        text: `You will not be able to turn back on your DAppNode from the admin UI.`,
+        label: "I am sure, shutdown",
+        onClick: resolve,
+        variant: "danger"
+      })
+    );
+
+    await api.poweroffHost({}, { toastMessage: `Shutting down host...` });
+  }
+
+  return (
+    <>
+      <SubTitle>Reboot host</SubTitle>
+      <Card className="backup">
+        {/* Get backup */}
+        <Columns>
+          <div>
+            <div className="subtle-header">REBOOT HOST</div>
+            <p>
+              Only use this functionality if it's stricly necessary and the last
+              resource to solve a problem.
+            </p>
+            <Button
+              onClick={reboot}
+              // disabled={isOnProgress}
+              variant="outline-danger"
+            >
+              Reboot
+            </Button>
+          </div>
+
+          {/* Restore backup */}
+          <div>
+            <div className="subtle-header">SHUTDOWN HOST</div>
+            <p>
+              You will not be able to start your DAppNode from the admin UI, you
+              will have to do it manually.
+            </p>
+            <Button
+              onClick={shutdown}
+              // disabled={isOnProgress}
+              variant="outline-danger"
+            >
+              Shutdown
+            </Button>
+          </div>
+        </Columns>
+      </Card>
+    </>
+  );
+}
+
+export default RebootHost;

--- a/build/src/src/pages/system/components/SystemHome.jsx
+++ b/build/src/src/pages/system/components/SystemHome.jsx
@@ -4,17 +4,16 @@ import { title } from "../data";
 import StaticIp from "./StaticIp";
 import AutoUpdates from "./AutoUpdates";
 import ChangeHostUserPassword from "./ChangeHostUserPassword";
+import RebootHost from "./RebootHost";
 import Title from "components/Title";
 
 const SystemHome = () => (
   <>
     <Title title={title} />
-
     <ChangeHostUserPassword />
-
     <AutoUpdates />
-
     <StaticIp />
+    <RebootHost />
   </>
 );
 

--- a/build/src/src/pages/system/components/SystemHome.jsx
+++ b/build/src/src/pages/system/components/SystemHome.jsx
@@ -4,7 +4,7 @@ import { title } from "../data";
 import StaticIp from "./StaticIp";
 import AutoUpdates from "./AutoUpdates";
 import ChangeHostUserPassword from "./ChangeHostUserPassword";
-import RebootHost from "./RebootHost";
+import PowerManagment from "./PowerManagment";
 import Title from "components/Title";
 
 const SystemHome = () => (
@@ -13,7 +13,7 @@ const SystemHome = () => (
     <ChangeHostUserPassword />
     <AutoUpdates />
     <StaticIp />
-    <RebootHost />
+    <PowerManagment />
   </>
 );
 


### PR DESCRIPTION
Two buttons with a simple description calling @vdo developed commands in the DAPPMANAGER.

![mainview](https://user-images.githubusercontent.com/35266934/62890029-dfb23480-bd42-11e9-8cd2-6d45b1b5b281.png)

#### Reboot 
If you click this modal will show up

![reboot1](https://user-images.githubusercontent.com/35266934/62890066-f22c6e00-bd42-11e9-8ade-3495b4009171.png)

#### Shutdown
If you click this modal will show up

![shutdown1](https://user-images.githubusercontent.com/35266934/62890100-04a6a780-bd43-11e9-8970-6c47e5502e46.png)


If you click "Shutdown" a second modal will show up

![shutdown2](https://user-images.githubusercontent.com/35266934/62890106-083a2e80-bd43-11e9-9fd5-d746af6fa948.png)

Then the shutdown is executed
 