### PR TITLE
Auto complete file manager paths with URL params

### DIFF
--- a/build/src/src/pages/packages/components/PackageInterface.jsx
+++ b/build/src/src/pages/packages/components/PackageInterface.jsx
@@ -87,7 +87,7 @@ const PackageInterface = ({
     {
       name: "File Manager",
       subPath: "file-manager",
-      render: () => <FileManager dnp={dnp} />,
+      render: ({ ...props }) => <FileManager {...props} dnp={dnp} />,
       available: true
     },
     // DnpSpecific is a variable dynamic per DNP component

--- a/build/src/src/pages/packages/components/PackageViews/FileManager/From.jsx
+++ b/build/src/src/pages/packages/components/PackageViews/FileManager/From.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import api from "API/rpcMethods";
 // Components
@@ -10,52 +10,62 @@ import dataUriToBlob from "utils/dataUriToBlob";
 import { saveAs } from "file-saver";
 import { stringSplit } from "utils/strings";
 
-function From({ id }) {
-  const [fromPath, setFromPath] = useState("");
+function From({ id, from }) {
+  const [fromPathInput, setFromPathInput] = useState("");
 
-  async function downloadFile() {
-    try {
-      /**
-       * [copyFileFrom]
-       * Copy file from a DNP and download it on the client
-       *
-       * @param {string} id DNP .eth name
-       * @param {string} fromPath path to copy file from
-       * - If path = path to a file: "/usr/src/app/config.json".
-       *   Downloads and sends that file
-       * - If path = path to a directory: "/usr/src/app".
-       *   Downloads all directory contents, tar them and send as a .tar.gz
-       * - If path = relative path: "config.json".
-       *   Path becomes $WORKDIR/config.json, then downloads and sends that file
-       *   Same for relative paths to directories.
-       * @returns {string} dataUri = "data:application/zip;base64,UEsDBBQAAAg..."
-       */
-      const dataUri = await api.copyFileFrom(
-        { id, fromPath },
-        { toastMessage: `Copying file from ${shortName(id)} ${fromPath}...` }
-      );
-      if (!dataUri) return;
+  const downloadFile = useCallback(
+    async fromPath => {
+      try {
+        /**
+         * [copyFileFrom]
+         * Copy file from a DNP and download it on the client
+         *
+         * @param {string} id DNP .eth name
+         * @param {string} fromPath path to copy file from
+         * - If path = path to a file: "/usr/src/app/config.json".
+         *   Downloads and sends that file
+         * - If path = path to a directory: "/usr/src/app".
+         *   Downloads all directory contents, tar them and send as a .tar.gz
+         * - If path = relative path: "config.json".
+         *   Path becomes $WORKDIR/config.json, then downloads and sends that file
+         *   Same for relative paths to directories.
+         * @returns {string} dataUri = "data:application/zip;base64,UEsDBBQAAAg..."
+         */
+        const dataUri = await api.copyFileFrom(
+          { id, fromPath },
+          { toastMessage: `Copying file from ${shortName(id)} ${fromPath}...` }
+        );
+        if (!dataUri) return;
 
-      const blob = dataUriToBlob(dataUri);
-      const fileName = parseFileName(fromPath, blob.type);
+        const blob = dataUriToBlob(dataUri);
+        const fileName = parseFileName(fromPath, blob.type);
 
-      saveAs(blob, fileName);
-    } catch (e) {
-      console.error(`Error on copyFileFrom ${id} ${fromPath}: ${e.stack}`);
+        saveAs(blob, fileName);
+      } catch (e) {
+        console.error(`Error on copyFileFrom ${id} ${fromPath}: ${e.stack}`);
+      }
+    },
+    [id]
+  );
+
+  useEffect(() => {
+    if (from) {
+      setFromPathInput(from);
+      downloadFile(from);
     }
-  }
+  }, [from, downloadFile]);
 
   return (
     <div className="card-subgroup">
       {/* FROM, chose path */}
       <Input
         placeholder="Container from path"
-        value={fromPath}
-        onValueChange={setFromPath}
+        value={fromPathInput}
+        onValueChange={setFromPathInput}
         append={
           <Button
-            onClick={downloadFile}
-            disabled={!fromPath}
+            onClick={() => downloadFile(fromPathInput)}
+            disabled={!fromPathInput}
             variant="dappnode"
           >
             Download

--- a/build/src/src/pages/packages/components/PackageViews/FileManager/To.jsx
+++ b/build/src/src/pages/packages/components/PackageViews/FileManager/To.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import * as a from "../../../actions";
@@ -11,9 +11,13 @@ import humanFileSize from "utils/humanFileSize";
 
 const fileSizeWarning = 1e6;
 
-function To({ id, copyFileTo }) {
+function To({ id, copyFileTo, to }) {
   const [file, setFile] = useState(null);
   const [toPath, setToPath] = useState("");
+
+  useEffect(() => {
+    if (to) setToPath(to);
+  }, [to]);
 
   const { name, size } = file || {};
 

--- a/build/src/src/pages/packages/components/PackageViews/FileManager/index.jsx
+++ b/build/src/src/pages/packages/components/PackageViews/FileManager/index.jsx
@@ -1,21 +1,45 @@
 import React from "react";
+
 import PropTypes from "prop-types";
 // Components
 import Card from "components/Card";
 import To from "./To";
 import From from "./From";
 
-function FileManager({ dnp }) {
+/**
+ * Additional feature to auto-complete the from and to paths
+ * Since it's not critical, errors are logged and ignored
+ * @param {string} searchQuery
+ */
+function fetchParamsFromExtraUrl(searchQuery) {
+  try {
+    if (!searchQuery) return {};
+    const searchParams = new URLSearchParams(searchQuery);
+    if (!searchParams) return {};
+    return {
+      from: searchParams.get("from"),
+      to: searchParams.get("to")
+    };
+  } catch (e) {
+    console.error(`Error parsing extra URL: ${e.stack}`);
+    return {};
+  }
+}
+
+function FileManager({ location, dnp }) {
   const id = dnp.name;
+
+  const { from, to } = fetchParamsFromExtraUrl(location.search);
+
   return (
     <Card spacing divider className="file-manager">
       <div>
         <div className="subtle-header">Upload file to package</div>
-        <To id={id} />
+        <To id={id} to={to} />
       </div>
       <div>
         <div className="subtle-header">Download file from package</div>
-        <From id={id} />
+        <From id={id} from={from} />
       </div>
     </Card>
   );


### PR DESCRIPTION
Autofill and download files with the a URL as
http://my.dappnode/#/packages/ipfs.dnp.dappnode.eth/file-manager?from=%2Fdata%2Fipfs%2Fconfig
```
http://my.dappnode/#/packages/{dnp-full-name}/file-manager?from={encodeURIComponent(fromPath)}
```

---

Autofill only path to upload files with
http://my.dappnode/#/packages/ipfs.dnp.dappnode.eth/file-manager?to=%2Fdata%2Fipfs%2Fconfig
```
http://my.dappnode/#/packages/{dnp-full-name}/file-manager?to={encodeURIComponent(fromPath)}
```

---

![demo-download-link-min](https://user-images.githubusercontent.com/35266934/71030672-332df800-2112-11ea-968a-108c1bdcc5c3.gif)
